### PR TITLE
feat: vim movement keys

### DIFF
--- a/src/input_handler/mod.rs
+++ b/src/input_handler/mod.rs
@@ -158,13 +158,13 @@ impl InputHandler {
                         SelectablePanel::Commands => locked_data.docker_command_end(),
                     }
                 }
-                KeyCode::Up => self.previous(),
+                KeyCode::Up | KeyCode::Char('k') => self.previous(),
                 KeyCode::PageUp => {
                     for _ in 0..=6 {
                         self.previous()
                     }
                 }
-                KeyCode::Down => self.next(),
+                KeyCode::Down | KeyCode::Char('j')=> self.next(),
                 KeyCode::PageDown => {
                     for _ in 0..=6 {
                         self.next()

--- a/src/ui/draw_blocks.rs
+++ b/src/ui/draw_blocks.rs
@@ -475,7 +475,7 @@ pub fn draw_help_box<B: Backend>(f: &mut Frame<'_, B>) {
     let description_text = format!("\n{}", DESCRIPTION);
 
     let mut help_text = String::from("\n  ( tab )  or ( alt+tab ) to change panels");
-    help_text.push_str("\n  ( ↑ ↓ ← → ) to change selected line");
+    help_text.push_str("\n  ( ↑ ↓ ← → ) or ( j k ) to change selected line");
     help_text.push_str("\n  ( enter ) to send docker container commands");
     help_text.push_str("\n  ( h ) to toggle this help information");
     help_text.push_str(


### PR DESCRIPTION
This allows 'j' and 'k' to move through the menus.