### PR TITLE
fix(draw_blocks): correct pane-navigation tooltip

### DIFF
--- a/src/ui/draw_blocks.rs
+++ b/src/ui/draw_blocks.rs
@@ -474,7 +474,7 @@ pub fn draw_help_box<B: Backend>(f: &mut Frame<'_, B>) {
 
     let description_text = format!("\n{}", DESCRIPTION);
 
-    let mut help_text = String::from("\n  ( tab )  or ( alt+tab ) to change panels");
+    let mut help_text = String::from("\n  ( tab )  or ( shift+tab ) to change panels");
     help_text
         .push_str("\n  ( ↑ ↓ ) or ( j k ) or (PgUp PgDown) or (Home End) to change selected line");
     help_text.push_str("\n  ( enter ) to send docker container commands");


### PR DESCRIPTION
Help tooltip is incorrectly labeled as 'alt+tab' for backwards pane navigation. It should be labeled as 'shift+tab' as per the functionality of [`Backtab`](https://github.com/mrjackwills/oxker/blob/main/src/input_handler/mod.rs#L147) from the [`crossterm`](https://docs.rs/crossterm/latest/crossterm/event/enum.KeyCode.html#variant.BackTab) crate.