### PR TITLE
Removing `.as_ref()` calls on constraints methods

### DIFF
--- a/src/ui/draw_blocks.rs
+++ b/src/ui/draw_blocks.rs
@@ -24,7 +24,6 @@ use crate::{
 use super::gui_state::{BoxLocation, DeleteButton, Region};
 use super::{GuiState, SelectablePanel};
 
-#[rustfmt::skip]
 const NAME_TEXT: &str = r#"
                           88                               
                           88                               

--- a/src/ui/draw_blocks.rs
+++ b/src/ui/draw_blocks.rs
@@ -24,14 +24,15 @@ use crate::{
 use super::gui_state::{BoxLocation, DeleteButton, Region};
 use super::{GuiState, SelectablePanel};
 
+#[rustfmt::skip]
 const NAME_TEXT: &str = r#"
-                          88
-                          88
-                          88
+                          88                               
+                          88                               
+                          88                               
  ,adPPYba,   8b,     ,d8  88   ,d8    ,adPPYba,  8b,dPPYba,
 a8"     "8a   `Y8, ,8P'   88 ,a8"    a8P_____88  88P'   "Y8
-8b       d8     )888(     8888[      8PP"""""""  88
-"8a,   ,a8"   ,d8" "8b,   88`"Yba,   "8b,   ,aa  88
+8b       d8     )888(     8888[      8PP"""""""  88        
+"8a,   ,a8"   ,d8" "8b,   88`"Yba,   "8b,   ,aa  88        
  `"YbbdP"'   8P'     `Y8  88   `Y8a   `"Ybbd8"'  88        "#;
 
 const NAME: &str = env!("CARGO_PKG_NAME");

--- a/src/ui/draw_blocks.rs
+++ b/src/ui/draw_blocks.rs
@@ -25,13 +25,13 @@ use super::gui_state::{BoxLocation, DeleteButton, Region};
 use super::{GuiState, SelectablePanel};
 
 const NAME_TEXT: &str = r#"
-                          88                               
-                          88                               
-                          88                               
+                          88
+                          88
+                          88
  ,adPPYba,   8b,     ,d8  88   ,d8    ,adPPYba,  8b,dPPYba,
 a8"     "8a   `Y8, ,8P'   88 ,a8"    a8P_____88  88P'   "Y8
-8b       d8     )888(     8888[      8PP"""""""  88        
-"8a,   ,a8"   ,d8" "8b,   88`"Yba,   "8b,   ,aa  88        
+8b       d8     )888(     8888[      8PP"""""""  88
+"8a,   ,a8"   ,d8" "8b,   88`"Yba,   "8b,   ,aa  88
  `"YbbdP"'   8P'     `Y8  88   `Y8a   `"Ybbd8"'  88        "#;
 
 const NAME: &str = env!("CARGO_PKG_NAME");
@@ -445,7 +445,7 @@ pub fn heading_bar<B: Backend>(
 
     let split_bar = Layout::default()
         .direction(Direction::Horizontal)
-        .constraints(splits.as_ref())
+        .constraints(splits)
         .split(area);
     if has_containers {
         // Draw loading icon, or not, and a prefix with a single space
@@ -458,7 +458,7 @@ pub fn heading_bar<B: Backend>(
         let container_splits = header_data.iter().map(|i| i.2).collect::<Vec<_>>();
         let headers_section = Layout::default()
             .direction(Direction::Horizontal)
-            .constraints(container_splits.as_ref())
+            .constraints(container_splits)
             .split(split_bar[1]);
 
         // draw the actual header blocks

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -250,7 +250,7 @@ fn draw_frame<B: Backend>(
     // Containers + docker commands
     let top_panel = Layout::default()
         .direction(Direction::Horizontal)
-        .constraints(top_split.as_ref())
+        .constraints(top_split)
         .split(upper_main[0]);
 
     let lower_split = if has_containers {
@@ -262,7 +262,7 @@ fn draw_frame<B: Backend>(
     // Split into 2, logs, and optional charts
     let lower_main = Layout::default()
         .direction(Direction::Vertical)
-        .constraints(lower_split.as_ref())
+        .constraints(lower_split)
         .split(upper_main[1]);
 
     draw_blocks::containers(app_data, top_panel[0], f, gui_state, &column_widths);


### PR DESCRIPTION
<h1 align="center">Removing .as_ref() calls on constraints methods</h1>

## Problem Statement

During a routine build process, it was observed that Oxker's AUR package encountered difficulties. To diagnose the problem, I cloned the source and attempted a local build. The build process revealed errors related to the constraint methods' reference passing calls, which specifically required a `::<T>constraint()` type.

## Implemented Solution

To resolve this issue, the `.as_ref()` calls in the constraint methods have been removed. This simplification not only rectifies the build errors but also contributes to more straightforward and readable code.

## Considerations for Future Enhancements

While this solution addresses the immediate build issues, it's important to remain open to the possibility that `.as_ref()` calls might be necessary under certain circumstances. If such a need arises, specifying a more explicit type in the constraint method calls will be considered.

## Commit Summary

- `refactor(draw_blocks.rs)`: Removed unnecessary `.as_ref()` calls in constraint methods to enhance code readability and resolve build issues.
- `refactor(mod.rs)`: Similarly, removed redundant `.as_ref()` calls in constraint methods, streamlining the codebase.

Best Regards,
Daniel Boll 🎴