### PR TITLE
perf: remove unnecessary cpu_stats clone

### DIFF
--- a/src/docker_data/mod.rs
+++ b/src/docker_data/mod.rs
@@ -98,14 +98,9 @@ impl DockerData {
             let online_cpus = f64::from(stats.cpu_stats.as_ref().map_or(0, |i| {
                 i.online_cpus.unwrap_or_else(|| {
                     u32::try_from(
-                        stats
-                            .cpu_stats
-                            .clone()
-                            .unwrap_or_default()
-                            .cpu_usage
-                            .unwrap_or_default()
-                            .percpu_usage
+                        i.cpu_usage
                             .as_ref()
+                            .and_then(|usage| usage.percpu_usage.as_ref())
                             .map_or(0, std::vec::Vec::len),
                     )
                     .unwrap_or_default()


### PR DESCRIPTION
Just noticed a small optimization opportunity:
In the `calculate_usage` function inside `docker_data/mod.rs` , the previous code cloned `stats.cpu_stats` inside a closure where `cpu_stats` was already borrowed (`|i|`).
That part of the code was replaced to just use the already borrowed `cpu_stats` when calculating the length of the list of per-CPU usage values