### PR TITLE
fix: replace bollard::secret with bollard::models

### DIFF
--- a/src/app_data/container_state.rs
+++ b/src/app_data/container_state.rs
@@ -5,7 +5,7 @@ use std::{
     net::IpAddr,
 };
 
-use bollard::secret::{ContainerSummaryHealthStatusEnum, PortSummary};
+use bollard::models::{ContainerSummaryHealthStatusEnum, PortSummary};
 use jiff::{Timestamp, tz::TimeZone};
 use ratatui::{
     layout::Size,
@@ -351,23 +351,23 @@ impl From<(&str, &ContainerStatus)> for State {
 /// Need status, to check if container is unhealthy or not
 impl
     From<(
-        &bollard::secret::ContainerSummaryStateEnum,
+        &bollard::models::ContainerSummaryStateEnum,
         &ContainerStatus,
     )> for State
 {
     fn from(
         (input, status): (
-            &bollard::secret::ContainerSummaryStateEnum,
+            &bollard::models::ContainerSummaryStateEnum,
             &ContainerStatus,
         ),
     ) -> Self {
         match input {
-            bollard::secret::ContainerSummaryStateEnum::DEAD => Self::Dead,
-            bollard::secret::ContainerSummaryStateEnum::EXITED => Self::Exited,
-            bollard::secret::ContainerSummaryStateEnum::PAUSED => Self::Paused,
-            bollard::secret::ContainerSummaryStateEnum::REMOVING => Self::Removing,
-            bollard::secret::ContainerSummaryStateEnum::RESTARTING => Self::Restarting,
-            bollard::secret::ContainerSummaryStateEnum::RUNNING => {
+            bollard::models::ContainerSummaryStateEnum::DEAD => Self::Dead,
+            bollard::models::ContainerSummaryStateEnum::EXITED => Self::Exited,
+            bollard::models::ContainerSummaryStateEnum::PAUSED => Self::Paused,
+            bollard::models::ContainerSummaryStateEnum::REMOVING => Self::Removing,
+            bollard::models::ContainerSummaryStateEnum::RESTARTING => Self::Restarting,
+            bollard::models::ContainerSummaryStateEnum::RUNNING => {
                 if status.unhealthy() {
                     Self::Running(RunningState::Unhealthy)
                 } else {
@@ -382,13 +382,13 @@ impl
 /// Again, need status, to check if container is unhealthy or not
 impl
     From<(
-        Option<&bollard::secret::ContainerSummaryStateEnum>,
+        Option<&bollard::models::ContainerSummaryStateEnum>,
         &ContainerStatus,
     )> for State
 {
     fn from(
         (input, status): (
-            Option<&bollard::secret::ContainerSummaryStateEnum>,
+            Option<&bollard::models::ContainerSummaryStateEnum>,
             &ContainerStatus,
         ),
     ) -> Self {

--- a/src/app_data/mod.rs
+++ b/src/app_data/mod.rs
@@ -1,4 +1,4 @@
-use bollard::{models::ContainerSummary, secret::ContainerInspectResponse};
+use bollard::models::{ContainerSummary, ContainerInspectResponse};
 use core::fmt;
 use parking_lot::Mutex;
 use ratatui::{layout::Size, text::Text, widgets::ListState};
@@ -997,7 +997,7 @@ impl AppData {
                 let state = State::from((
                     i.state
                         .as_ref()
-                        .map_or(&bollard::secret::ContainerSummaryStateEnum::DEAD, |z| z),
+                        .map_or(&bollard::models::ContainerSummaryStateEnum::DEAD, |z| z),
                     &status,
                 ));
                 let image = i

--- a/src/docker_data/mod.rs
+++ b/src/docker_data/mod.rs
@@ -4,8 +4,8 @@ use bollard::{
         InspectContainerOptions, ListContainersOptions, LogsOptions, RemoveContainerOptions,
         RestartContainerOptions, StartContainerOptions, StatsOptions, StopContainerOptions,
     },
-    secret::ContainerStatsResponse,
-    service::ContainerSummary,
+    models::ContainerStatsResponse,
+    models::ContainerSummary,
 };
 use futures_util::StreamExt;
 use parking_lot::Mutex;
@@ -476,7 +476,7 @@ impl DockerData {
 #[allow(clippy::float_cmp)]
 mod tests {
 
-    use bollard::secret::{ContainerCpuStats, ContainerCpuUsage};
+    use bollard::models::{ContainerCpuStats, ContainerCpuUsage};
 
     use super::*;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -259,7 +259,7 @@ mod tests {
             size_rw: None,
             size_root_fs: None,
             labels: None,
-            state: Some(bollard::secret::ContainerSummaryStateEnum::from_str(state).unwrap()),
+            state: Some(bollard::models::ContainerSummaryStateEnum::from_str(state).unwrap()),
             status: Some(format!("Up {index} hour")),
             host_config: None,
             network_settings: None,

--- a/src/ui/draw_blocks/inspect.rs
+++ b/src/ui/draw_blocks/inspect.rs
@@ -144,7 +144,7 @@ mod tests {
         config::{AppColors, Keymap},
         ui::draw_blocks::tests::{get_result, test_setup},
     };
-    use bollard::secret::{
+    use bollard::models::{
         ContainerConfig, ContainerInspectResponse, ContainerState, ContainerStateStatusEnum,
         DriverData, EndpointSettings, HostConfig, HostConfigLogConfig, MountPoint,
         MountPointTypeEnum, NetworkSettings, RestartPolicy, RestartPolicyNameEnum,
@@ -632,7 +632,7 @@ mod tests {
         annotations: None,
         cap_add: None,
         cap_drop: None,
-        cgroupns_mode: Some(bollard::secret::HostConfigCgroupnsModeEnum::HOST),
+        cgroupns_mode: Some(bollard::models::HostConfigCgroupnsModeEnum::HOST),
         dns: Some(vec![]),
         dns_options: Some(vec![]),
         dns_search: Some(vec![]),
@@ -654,7 +654,7 @@ mod tests {
         shm_size: Some(268435456),
         sysctls: None,
         runtime: Some("runc".to_owned()),
-        isolation: Some(bollard::secret::HostConfigIsolationEnum::EMPTY),
+        isolation: Some(bollard::models::HostConfigIsolationEnum::EMPTY),
         masked_paths: Some(vec![
             "/proc/acpi".to_owned(),
             "/proc/asound".to_owned(),


### PR DESCRIPTION
## Problem

`bollard` v0.20.2 made the `secret` module private, moving all public types into `models`. Because `cargo install` resolves dependencies fresh on every install (no lockfile), any user installing oxker today pulls in bollard v0.20.2 and gets 15+ compilation errors like:

```
error[E0603]: enum `ContainerSummaryStateEnum` is private
  --> src/app_data/container_state.rs:370:13
   |
   |             bollard::secret::ContainerSummaryStateEnum::RUNNING => {
   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^ private enum
```

## Solution

Replace all references to `bollard::secret::` with `bollard::models::` across 5 files:

- `src/app_data/mod.rs`
- `src/app_data/container_state.rs`
- `src/docker_data/mod.rs`
- `src/main.rs`
- `src/ui/draw_blocks/inspect.rs`

This is a pure path change — no logic is altered. The types themselves are unchanged, they just moved modules in bollard's public API.