### PR TITLE
fix: terminal content erased on exit

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -8,7 +8,7 @@ use parking_lot::Mutex;
 use ratatui::{
     Frame, Terminal,
     backend::CrosstermBackend,
-    layout::{Constraint, Direction, Layout, Position},
+    layout::{Constraint, Direction, Layout},
 };
 use std::{
     collections::HashSet,
@@ -44,7 +44,6 @@ const POLL_RATE: Duration = std::time::Duration::from_millis(50);
 
 pub struct Ui {
     app_data: Arc<Mutex<AppData>>,
-    cursor_position: Position,
     gui_state: Arc<Mutex<GuiState>>,
     input_tx: Sender<InputMessages>,
     is_running: Arc<AtomicBool>,
@@ -75,11 +74,9 @@ impl Ui {
         rerender: Arc<Rerender>,
     ) {
         match Self::setup_terminal() {
-            Ok(mut terminal) => {
-                let cursor_position = terminal.get_cursor_position().unwrap_or_default();
+            Ok(terminal) => {
                 let mut ui = Self {
                     app_data,
-                    cursor_position,
                     gui_state,
                     input_tx,
                     is_running,
@@ -117,16 +114,12 @@ impl Ui {
 
     /// reset the terminal back to default settings
     pub fn reset_terminal(&mut self) -> Result<()> {
-        self.terminal.clear()?;
-
         execute!(
             self.terminal.backend_mut(),
             LeaveAlternateScreen,
             DisableMouseCapture
         )?;
         disable_raw_mode()?;
-        self.terminal.clear().ok();
-        self.terminal.set_cursor_position(self.cursor_position)?;
         Ok(self.terminal.show_cursor()?)
     }
 


### PR DESCRIPTION
Title:
fix: terminal content erased on exit

Description:
## Problem

When exiting oxker, the terminal's previous content (e.g. output from commands run before oxker) is erased.

## Root Cause

Two bugs in `reset_terminal()` that masked each other:

1. `terminal.clear()` executed **after** `LeaveAlternateScreen` wiped the main screen buffer that `LeaveAlternateScreen` had just restored
2. `cursor_position` was saved **after** `EnterAlternateScreen` (capturing the alternate screen's `0,0` position), then `set_cursor_position(0,0)` moved the
cursor to the top-left of the main screen, causing subsequent output to overwrite existing content

## Fix

Remove the redundant operations in `reset_terminal()`. `LeaveAlternateScreen` (CSI ?1049l) automatically restores both the main screen content and the cursor
position — no manual intervention needed.

## Reproduce

```bash
echo "this should still be visible after exit" && oxker
# Press q to exit — the echo output should remain
